### PR TITLE
Encode everything to ASCII

### DIFF
--- a/quasselgrep
+++ b/quasselgrep
@@ -52,7 +52,7 @@ class QuasselGrep:
 		if query.options.debug:
 			for res in results: print res[0]
 		elif results:
-			for res in results: print query.format(res)
+			for res in results: print query.format(res).encode('ascii', 'ignore')
 		else:
 			print "No results found."
 


### PR DESCRIPTION
and discard characters that cannot be printed

Fixed "UnicodeEncodeError: 'ascii' codec can't encode character u'\U0001f60a' in position 54: ordinal not in range(128)"