### PR TITLE
Port to Python 3 using python-modernize

### DIFF
--- a/quasselgrep/client.py
+++ b/quasselgrep/client.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import socket
 
-from util import salt_and_hash, getdata, escape
+from .util import salt_and_hash, getdata, escape
 
 def start(options, search, program):
 	if not getattr(options, 'hostname', None):
-		print "Error: You must supply a hostname."
+		print("Error: You must supply a hostname.")
 		return
 	if not getattr(options, 'password', None):
-		print "Error: You must supply a password"
+		print("Error: You must supply a password")
 		return
 
 	port = options.port if hasattr(options, 'port') else 9001
@@ -21,7 +23,7 @@ def start(options, search, program):
 	response = getdata(sock)[0]
 
 	if response[:5] != 'SALT=':
-		print 'Error: Did not understand server response.'
+		print('Error: Did not understand server response.')
 		return
 
 	salt = response[5:]

--- a/quasselgrep/config.py
+++ b/quasselgrep/config.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 
 defaults = {
@@ -22,13 +24,13 @@ def update_options(options):
 
 	if conf_file:
 		try:
-			execfile(conf_file, namespace)
+			exec(compile(open(conf_file).read(), conf_file, 'exec'), namespace)
 		except IOError:
-			print "Error: Could not open %s for reading; ignoring." % (conf_file)
+			print("Error: Could not open %s for reading; ignoring." % (conf_file))
 			use_config = False
 	else:
 		try:
-			execfile(defaults['config'], namespace)
+			exec(compile(open(defaults['config']).read(), defaults['config'], 'exec'), namespace)
 		except IOError:
 			use_config = False
 

--- a/quasselgrep/dateparse.py
+++ b/quasselgrep/dateparse.py
@@ -28,15 +28,18 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import absolute_import
+from __future__ import print_function
 import re
 import sys
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
+import six
 rcompile = re.compile
-from times import adatetime, timespan
-from times import fill_in, is_void, relative_days
-from times import TimeError
+from .times import adatetime, timespan
+from .times import fill_in, is_void, relative_days
+from .times import TimeError
 
 
 class DateParseError(Exception):
@@ -47,7 +50,7 @@ class DateParseError(Exception):
 
 def print_debug(level, msg, *args):
 	if level > 0:
-		print(("  " * (level - 1)) + (msg % args))
+		print((("  " * (level - 1)) + (msg % args)))
 
 
 # Parser element objects
@@ -73,7 +76,7 @@ class ParserBase(object):
 	"""
 
 	def to_parser(self, e):
-		if isinstance(e, basestring):
+		if isinstance(e, six.string_types):
 			return Regex(e)
 		else:
 			return e
@@ -453,7 +456,7 @@ class Regex(ParserBase):
 
 	def extract(self, match):
 		d = match.groupdict()
-		for key, value in d.iteritems():
+		for key, value in six.iteritems(d):
 			try:
 				value = int(value)
 				d[key] = value

--- a/quasselgrep/db.py
+++ b/quasselgrep/db.py
@@ -1,4 +1,5 @@
 
+from __future__ import absolute_import
 class Db:
 	def __init__(self):
 		pass

--- a/quasselgrep/output.py
+++ b/quasselgrep/output.py
@@ -1,4 +1,5 @@
-from msgtypes import *
+from __future__ import absolute_import
+from .msgtypes import *
 
 BUF_COL_WIDTH = 16
 

--- a/quasselgrep/quasselgrep.py
+++ b/quasselgrep/quasselgrep.py
@@ -1,10 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from db import Db
-from query import Query
-import dateparse
-from times import timespan
-import config
+from __future__ import absolute_import
+from __future__ import print_function
+from .db import Db
+from .query import Query
+from . import dateparse
+from .times import timespan
+from . import config
 
 import sys
 from datetime import datetime
@@ -50,11 +52,11 @@ class QuasselGrep:
 
 		results = query.run()
 		if query.options.debug:
-			for res in results: print res[0]
+			for res in results: print(res[0])
 		elif results:
-			for res in results: print query.format(res)
+			for res in results: print(query.format(res))
 		else:
-			print "No results found."
+			print("No results found.")
 
 	def setup_optparser(self):
 		"""Parse command line arguments using optarg"""
@@ -129,8 +131,8 @@ class QuasselGrep:
 
 		try:
 			config.update_options(options)
-		except ValueError, e:
-			print "Error: Invalid option: %s" % (e)
+		except ValueError as e:
+			print("Error: Invalid option: %s" % (e))
 			return
 
 		if args:
@@ -138,11 +140,11 @@ class QuasselGrep:
 
 		#Be a client, or a server.
 		if options.hostname and not self.server:
-			import client
+			from . import client
 			client.start(options, search, self)
 			return
 		if options.server and not self.server:
-			import server
+			from . import server
 			self.server = True
 			server.start(self, options)
 			return
@@ -150,14 +152,14 @@ class QuasselGrep:
 		db = Db()
 		try:
 			cursor = db.connect(options)
-		except Exception, e:
-			print "Error connecting to database: %s" % (e)
+		except Exception as e:
+			print("Error connecting to database: %s" % (e))
 			return
 
 		#Users connecting to a server need to authenticate
 		if self.server:
-			import server
-			from util import salt_hash
+			from . import server
+			from .util import salt_hash
 			if not options.username or not options.password:
 				raise server.AuthException('You must specify a quassel username and password.')
 
@@ -182,10 +184,10 @@ class QuasselGrep:
 
 			if start:
 				timerange = [start, end]
-				print "Searching from %s to %s." % (start, end)
+				print("Searching from %s to %s." % (start, end))
 			else:
 				timerange = None
-				print "Error: Couldn't parse %s as a date/time." % (options.timerange)
+				print("Error: Couldn't parse %s as a date/time." % (options.timerange))
 				return
 		else:
 			timerange = None

--- a/quasselgrep/query.py
+++ b/quasselgrep/query.py
@@ -1,10 +1,13 @@
-import output
-from msgtypes import *
+from __future__ import absolute_import
+from __future__ import print_function
+from . import output
+from .msgtypes import *
 
 from time import time
 from datetime import datetime
 import re
 from threading import Thread
+from six.moves import range
 
 maskre = re.compile('(?P<nick>.*)!(.*)@(.*)')
 MSG_NORMAL = 1
@@ -185,7 +188,7 @@ class Query:
 
 	def search_query(self, only_ids=False):
 		"""Normal query"""
-		params = self.filter_params(self.params.keys())
+		params = self.filter_params(list(self.params.keys()))
 		query = self.basequery(only_ids)
 		query.append(self.where_clause(params))
 
@@ -295,12 +298,12 @@ class Query:
 				self.execute_query(*self.search_query())
 			else:
 				query, params = self.search_query()
-				print query
-				print params
+				print(query)
+				print(params)
 				self.cursor.execute("EXPLAIN " + query, params)
 			results = self.cursor.fetchall()
 
-		print "Query completed in %.2f seconds" % (time() - start)
+		print("Query completed in %.2f seconds" % (time() - start))
 		return results
 
 	def execute_query(self, query, params=[]):
@@ -312,7 +315,7 @@ class Query:
 				thread.join(1)
 				if not thread.is_alive(): break
 		except KeyboardInterrupt:
-			print "Stopping."
+			print("Stopping.")
 			raise
 
 	def format(self, result):

--- a/quasselgrep/server.py
+++ b/quasselgrep/server.py
@@ -1,8 +1,10 @@
-from SocketServer import ThreadingTCPServer, TCPServer, BaseRequestHandler
+from __future__ import absolute_import
+from __future__ import print_function
+from six.moves.socketserver import ThreadingTCPServer, TCPServer, BaseRequestHandler
 from shlex import split
 from os import urandom
 
-from util import getdata
+from .util import getdata
 
 class AuthException(Exception):
 	pass
@@ -59,7 +61,7 @@ class QuasselGrepHandler(BaseRequestHandler):
 
 		try:
 			query = program.run(options, search, salt)
-		except AuthException, e:
+		except AuthException as e:
 			socket.sendall('Error: %s\n' % (e))
 			socket.close()
 			return
@@ -82,4 +84,4 @@ def start(program, options):
 	server.options = options
 
 	server.serve_forever()
-	print "Finishing."
+	print("Finishing.")

--- a/quasselgrep/times.py
+++ b/quasselgrep/times.py
@@ -28,9 +28,11 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
+from __future__ import absolute_import
 import calendar
 import copy
 from datetime import date, datetime, timedelta
+import six
 
 
 class TimeError(Exception):
@@ -170,7 +172,7 @@ class adatetime(object):
 		"""
 
 		newadatetime = self.copy()
-		for key, value in kwargs.iteritems():
+		for key, value in six.iteritems(kwargs):
 			if key in self.units:
 				setattr(newadatetime, key, value)
 			else:

--- a/quasselgrep/util.py
+++ b/quasselgrep/util.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from Crypto.Hash import SHA
 
 def getdata(socket):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
+from __future__ import absolute_import
 import os
 from setuptools import setup, find_packages
 
@@ -20,6 +21,7 @@ except ImportError:
 REQUIREMENTS = [
     'python-dateutil',
     'pycrypto',
+    'six'
 ]
 
 setup(
@@ -45,10 +47,11 @@ setup(
 
     packages=find_packages(),
 
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers for others
+    # See https://pypi.python3.org/pypi?%3Aaction=list_classifiers for others
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
     ],
 


### PR DESCRIPTION
I ran [python-modernize](https://pypi.python.org/pypi/modernize) over the codebase to convert things to Python 3. This automatic conversion seems to have been successful, but I haven't tested everything thoroughly... just that I was able to connect to a PostgreSQL database and read back logs.

As part of this change I added Python 3.6 to the list of supported versions in setup.py, and changed the "python" hashbangs in setup.py and quasselgrep to "python3".

This adds the [six](https://pypi.python.org/pypi/six) package as a dependency.

I have not tested if things are still backwards compatible with Python 2.7, but I believe they should be.

(See also #7).