### PR TITLE
Missing timestamps #19 

### DIFF
--- a/quasselgrep/db.py
+++ b/quasselgrep/db.py
@@ -14,6 +14,13 @@ class Db(object):
 
 			self.connection = dbmodule.connect(options.db_name, check_same_thread=False)
 			cursor = self.connection.cursor()
+
+			#Newer sqlite versions have timestamps in milliseconds.
+			cursor.execute('SELECT value FROM coreinfo WHERE key="schemaversion"')
+			results = cursor.fetchall()
+			if len(results) != 1:
+				raise ValueError('Incorrect sqlite schemaversion format')
+			options.sqlite_version = results[0][0]
 		elif options.db_type == 'postgres':
 			options.param_string = '%s'
 			try:

--- a/quasselgrep/db.py
+++ b/quasselgrep/db.py
@@ -20,7 +20,11 @@ class Db(object):
 			results = cursor.fetchall()
 			if len(results) != 1:
 				raise ValueError('Incorrect sqlite schemaversion format')
-			options.sqlite_version = results[0][0]
+			try:
+				#Schema version should be an integer, but this isn't guaranteed
+				options.sqlite_version = int(results[0][0])
+			except ValueError as e:
+				raise ValueError('Unexpected sqlite schemaversion %s, not an integer: %s' % (results[0][0], e))
 		elif options.db_type == 'postgres':
 			options.param_string = '%s'
 			try:


### PR DESCRIPTION
This PR fixes issue #19:
- on sqlite3 >= 31, timestamps now display properly
- on sqlite3 >= 31, filtering based on timestamps (-t option) now works

For sqlite3 databases, we read schemaversion on connect and store it into the options object. That way, we can deduce the timestamp unit (milliseconds or seconds) from other files. This approach was suggested by @digitalcircuit in #19 [1].

I've just started using quasselgrep, so perhaps I missed something. Let me know if that's the case. Also, I cannot test with databases < 31, but old behavior should be left untouched in that case.

[1] https://github.com/fish-face/quasselgrep/issues/19#issuecomment-482753420