### PR TITLE
query: Increase Postgres timestamp precision

### DIFF
--- a/quasselgrep/__main__.py
+++ b/quasselgrep/__main__.py
@@ -109,6 +109,9 @@ class QuasselGrep(object):
 		parser.add_option('-C', '--context', dest='context', metavar='LINES',
 						  help='Include this many lines of context with results.')
 
+		parser.add_option('--datetime-format', dest='datetime_format', metavar='STRFTIME',
+				help='Specify the date/time format string for results (see Python strftime)')
+
 		parser.add_option('--debug', dest='debug', action='store_true',
 				help='Display information about the query instead of running it')
 

--- a/quasselgrep/config.py
+++ b/quasselgrep/config.py
@@ -11,7 +11,8 @@ defaults = {
 	'db_port' : 5432,
 	'db_password' : None,
 
-	'whole_line' : False
+	'whole_line' : False,
+	'datetime_format' : '%Y-%m-%d %H:%M:%S'
 }
 
 def loadconfig(filename, namespace):

--- a/quasselgrep/output.py
+++ b/quasselgrep/output.py
@@ -3,12 +3,12 @@ from .msgtypes import *
 
 BUF_COL_WIDTH = 16
 
-def format(time, msg_type, message, sender, buffer):
+def format(datetime_format, time, msg_type, message, sender, buffer):
 	formatted = ''
 	if buffer:
 		formatted += '(%s)' % (buffer)
 		formatted += ' ' * max(0,(BUF_COL_WIDTH - len(formatted)))
-	formatted += '[%s] ' % time
+	formatted += '[%s] ' % time.strftime(datetime_format)
 
 	try:
 		return formatted + parser_for_msgtype[msg_type](message, sender)

--- a/quasselgrep/query.py
+++ b/quasselgrep/query.py
@@ -58,6 +58,8 @@ class Query(object):
 				self.fromtime = timerange[0].strftime('%s')
 				self.totime = timerange[1].strftime('%s')
 
+		self.datetime_format = options.datetime_format
+
 		if options.inclusive:
 			self.msg_types = (MSG, NOTICE, ACTION, NICK, MODE, JOIN, PART, QUIT, KICK, TOPIC, INVITE, SPLITJOIN, SPLITQUIT)
 		else:
@@ -310,5 +312,5 @@ class Query(object):
 				sender = result[4]
 			buffer = result[5] if not self.buffer else None
 
-			yield output.format(time, type, message, sender, buffer)
+			yield output.format(self.datetime_format, time, type, message, sender, buffer)
 

--- a/quasselgrep/query.py
+++ b/quasselgrep/query.py
@@ -134,7 +134,7 @@ class Query(object):
 	def columns(self):
 		columns = []
 		if self.options.db_type == 'postgres':
-			columns.append('backlog.time::timestamp(0)')
+			columns.append('backlog.time::timestamp(6)')
 		elif self.options.db_type == 'sqlite':
 			columns.append("datetime(backlog.time, 'unixepoch') as time")
 		columns += ["backlog.type", "backlog.message", "sender.sender", "buffer.buffername", "network.networkname"]


### PR DESCRIPTION
## In short
* Increase [`timestamp` precision on PostgreSQL](https://www.postgresql.org/docs/current/datatype-datetime.html ) to show milliseconds
  * Makes it easier to distinguish identical messages sent next to each other
  * On pre-0.13 Quassel cores, no change
  * Additional formatting control might be useful in a separate pull request
* [SQLite is already fixed in a different pull request](https://github.com/fish-face/quasselgrep/pull/22 )
* Add `--datetime-format` to specify custom date/time format strings
  * E.g. `--datetime-format="%Y-%m-%d %H:%M:%S.%f"` shows microseconds
  * Default `%Y-%m-%d %H:%M:%S` matches current output

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Adds user customization, precision to Postgres timestamps
Risk | ★☆☆ *1/3* | May break if encountering an invalid date/time
Intrusiveness | ★★☆ *2/3* | Changes to configuration and output format, might interfere with other pull requests

## Details

Since 0.13, Quassel stores timestamps with millisecond precision.  However, quasselgrep has not been showing this [due to specifying `timestamp(0)`](https://www.postgresql.org/docs/current/datatype-datetime.html ).

Including the millisecond timestamp can help with distinguishing multiple identical messages next to each other, e.g. if someone posts ASCII art or spam.

The default output remains the same.  A custom timestamp format must be specified to show milliseconds.

## Testing

### Steps

1.  Set up quasselgrep with a Quassel core v0.13 or later
2.  Ensure there's some message activity in the core database
3.  Print the messages using quasselgrep's filtering
4.  Add `--datetime-format="%Y-%m-%d %H:%M:%S.%f"` to check with microseconds

### Before, message from Quassel 0.13+
```
[2022-05-28 03:35:22] <digitalcircuit> An example message.
```

### After, message from Quassel 0.13+ *using default date/time format*
```
[2022-05-28 03:35:22] <digitalcircuit> An example message.
```

### After, message from Quassel 0.13+ with `--datetime-format`
*Using `--datetime-format="%Y-%m-%d %H:%M:%S.%f"`*
```
[2022-05-28 03:35:22.329000] <digitalcircuit> An example message.
```