### PR TITLE
Remove future, __future__ imports, fix bug with Python > 3.6, update setup.py, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Mandatory:
 - python-dateutil
 
 Optional:
-- python-crypto (to run as client/server)
+- pycryptodome (to run as client/server)
 - psycopg2 (for PostgreSQL support)
 
 Installation

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ quasselgrep
 
 Tool for searching quassel logs from the commandline
 
+[![Packaging status](https://repology.org/badge/tiny-repos/quasselgrep.svg)](https://repology.org/project/quasselgrep/versions)
+[Gentoo overlay](https://github.com/jjakob/gentoo-overlay/net-irc/quasselgrep)
+
 Requirements
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ Tool for searching quassel logs from the commandline
 Requirements
 ---
 
-The python dateutil library is a requirement, and can be installed with pip:
+Mandatory:
+- python-dateutil
 
-	# pip install python-dateutil
-
-To run quasselgrep as a server or client, you'll need python's crypto module.
-For instance, on Debian-based systems, run:
-
-	# apt-get install python-crypto
+Optional:
+- python-crypto (to run as client/server)
+- psycopg2 (for PostgreSQL support)
 
 Installation
 ---
 
-You don't need to install quasselgrep to use it but it might be more convenient. To do so run:
+You don't need to install quasselgrep to use it but it might be more convenient. Install it via your system's package manager.
+
+If a package is not available for your OS, you can install it with pip:
 
 	# sudo pip install .
 
-from the root directory. You can also install it as a local user, or by directly running setup.py, of course. Having done this you will be able to run the `quasselgrep` command at the shell. If you don't install it like this, either use:
+from the root directory. You can also install it as a local user or in a virtualenv or by directly running setup.py. Having done this you will be able to run the `quasselgrep` command at the shell. If you don't install it like this, either use:
 
 	$ ./launch.py <options>
 

--- a/quasselgrep/__main__.py
+++ b/quasselgrep/__main__.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser as OptionParser
 from argparse import HelpFormatter as Formatter #IndentedHelpFormatter as Formatter
 from argparse import Namespace
 
-version = u'Quasselgrep 0.1\nCopyright (c) 2013 Chris Le Sueur\nThis program is licensed under the GNU General Public License'
+version = u'Quasselgrep 0.1\nCopyright (c) 2013 Chris Le Sueur\nCopyright (c) 2023 Jernej Jakob\nThis program is licensed under the GNU General Public License'
 usage = u'%(prog)s [options] <keywords>'
 
 def format_option_strings(self, option):

--- a/quasselgrep/__main__.py
+++ b/quasselgrep/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from builtins import object, str
 from .db import Db
 from .query import Query
 from . import dateparse

--- a/quasselgrep/__main__.py
+++ b/quasselgrep/__main__.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 from builtins import object, str
 from .db import Db
 from .query import Query

--- a/quasselgrep/__main__.py
+++ b/quasselgrep/__main__.py
@@ -12,7 +12,7 @@ from argparse import ArgumentParser as OptionParser
 from argparse import HelpFormatter as Formatter #IndentedHelpFormatter as Formatter
 from argparse import Namespace
 
-version = u'Quasselgrep 0.1\nCopyright (c) 2013 Chris Le Sueur\nCopyright (c) 2023 Jernej Jakob\nThis program is licensed under the GNU General Public License'
+version = u'Quasselgrep 0.2\nCopyright (c) 2013 Chris Le Sueur\nCopyright (c) 2023 Jernej Jakob\nThis program is licensed under the GNU General Public License'
 usage = u'%(prog)s [options] <keywords>'
 
 def format_option_strings(self, option):

--- a/quasselgrep/client.py
+++ b/quasselgrep/client.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 import sys
 import socket

--- a/quasselgrep/client.py
+++ b/quasselgrep/client.py
@@ -1,4 +1,3 @@
-from builtins import str
 import sys
 import socket
 from argparse import _StoreFalseAction, _StoreTrueAction

--- a/quasselgrep/config.py
+++ b/quasselgrep/config.py
@@ -14,7 +14,7 @@ defaults = {
 }
 
 def loadconfig(filename, namespace):
-    with open(filename, 'rbU') as fd:
+    with open(filename, 'rb') as fd:
         source = fd.read()
     code = compile(source, filename, 'exec')
     exec(code, namespace)

--- a/quasselgrep/config.py
+++ b/quasselgrep/config.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 defaults = {

--- a/quasselgrep/dateparse.py
+++ b/quasselgrep/dateparse.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Jernej Jakob <jernej.jakob@gmail.com>: Removed Python 2 compatibility
 # Copyright 2013 Chris Le Sueur.
 # From dateparse.py, part of Whoosh, a python search library:
 

--- a/quasselgrep/dateparse.py
+++ b/quasselgrep/dateparse.py
@@ -35,7 +35,6 @@ except NameError:
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-from builtins import object, str
 import re
 import sys
 from datetime import datetime, timedelta

--- a/quasselgrep/dateparse.py
+++ b/quasselgrep/dateparse.py
@@ -1,10 +1,3 @@
-from past.types import basestring
-
-try:
-	basestring
-except NameError:
-	basestring = str
-
 # Copyright 2013 Chris Le Sueur.
 # From dateparse.py, part of Whoosh, a python search library:
 
@@ -80,7 +73,7 @@ class ParserBase(object):
 	"""
 
 	def to_parser(self, e):
-		if isinstance(e, basestring):
+		if isinstance(e, str):
 			return Regex(e)
 		else:
 			return e

--- a/quasselgrep/dateparse.py
+++ b/quasselgrep/dateparse.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 from past.types import basestring
 
 try:

--- a/quasselgrep/db.py
+++ b/quasselgrep/db.py
@@ -1,5 +1,4 @@
 
-from builtins import object
 class Db(object):
 	def __init__(self):
 		pass

--- a/quasselgrep/output.py
+++ b/quasselgrep/output.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from .msgtypes import *
 
 BUF_COL_WIDTH = 16

--- a/quasselgrep/query.py
+++ b/quasselgrep/query.py
@@ -1,5 +1,3 @@
-from builtins import range
-from builtins import object
 from . import output
 from .msgtypes import *
 

--- a/quasselgrep/query.py
+++ b/quasselgrep/query.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import range
 from builtins import object
 from . import output

--- a/quasselgrep/server.py
+++ b/quasselgrep/server.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 from socketserver import ThreadingTCPServer, TCPServer, BaseRequestHandler
 from shlex import split

--- a/quasselgrep/server.py
+++ b/quasselgrep/server.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object

--- a/quasselgrep/server.py
+++ b/quasselgrep/server.py
@@ -1,4 +1,3 @@
-from builtins import object
 from socketserver import ThreadingTCPServer, TCPServer, BaseRequestHandler
 from shlex import split
 from os import urandom

--- a/quasselgrep/times.py
+++ b/quasselgrep/times.py
@@ -28,7 +28,6 @@
 # those of the authors and should not be interpreted as representing official
 # policies, either expressed or implied, of Matt Chaput.
 
-from builtins import object
 import calendar
 import copy
 from datetime import date, datetime, timedelta

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     author_email='',
     url='https://github.com/fish-face/quasselgrep',
     license="GPLv2",
+    python_requires=">=3.7",
     install_requires=REQUIREMENTS,
     keywords=['quassel', 'quasselgrep', 'irc', 'logs'],
     packages=find_packages(),
@@ -38,7 +39,12 @@ setup(
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers for others
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ setup(
     keywords=['quassel', 'quasselgrep', 'irc', 'logs'],
     packages=find_packages(),
 
+    extras_require = {
+        "PostgreSQL": ["psycopg2"],
+    },
+
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers for others
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = [
 
 setup(
     name='quasselgrep',
-    version='0.1',
+    version='0.2',
     description='quasselgrep',
     long_description=long_description,
     author='Chris Le Sueur',


### PR DESCRIPTION
- future imports are no longer necessary with all still maintained Python versions
- past import is not necessary
- open "universal newlines" mode is no longer supported (is now default)
- update setup.py:
  - only support Python >=3.7
  - add extras_require postgresql psycopg2
- update readme:
  - make dependencies clearer
  - add instruction to install from OS packages if available
  - add note about possibly using a virtualenv
  - add Repology badge
  - add link to Gentoo overlay
  - python-crypto is pycryptodome in Python 3
- add myself to copyright notices
- bump version to 0.2